### PR TITLE
docs: add keywords for python auth datafile feature spellcheck

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -79,6 +79,7 @@ Atlassian
 AtomicProjectConfigManager
 auth
 Auth0
+AuthDatafilePollingConfigManager
 Backoff
 Bartosz
 base64-encoded
@@ -445,6 +446,7 @@ Yura
 Zivolo
 __autoreleasing
 aar
+access_token
 accessor
 accessors
 add_to_cart


### PR DESCRIPTION
Summary
----------
- Added terms `AuthDatafilePollingConfigManager` and `access_token` to pass spelling checks in documentation `(README)`